### PR TITLE
docs: fix dead joomla.kabinary.com link + document repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ To get started with our modules:
    Browse this repository and download the latest version of the module ZIP file that suits your needs.
 
 2. **Follow the Installation Guide**  
-   Detailed instructions on installing and activating your module can be found on our [website](https://joomla.kabinary.com).
+   Detailed instructions on installing and activating your module can be found on our [website](https://modules.kabinary.com).
+
+## Repository Layout
+
+- `downloads/` - installable module ZIP archives, one folder per module
+- `updates/` - Joomla update-server XML manifests consumed by the Joomla updater
 
 ## Support
 


### PR DESCRIPTION
- Le lien d'installation pointait sur **joomla.kabinary.com qui répond 404** — remplacé par modules.kabinary.com (le domaine actuel du site, vérifié HTTP 200)
- Ajout d'une section *Repository Layout* (`downloads/` = ZIPs, `updates/` = manifests du update server Joomla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)